### PR TITLE
Add image drag-and-drop with base64 encoding

### DIFF
--- a/backend/crud/messages.py
+++ b/backend/crud/messages.py
@@ -2,6 +2,7 @@
 CRUD operations for Message entities.
 """
 
+import json
 from datetime import datetime
 from typing import List
 
@@ -30,6 +31,11 @@ async def create_message(
     Returns:
         Created message
     """
+    # Serialize image_data to JSON string if present
+    image_data_json = None
+    if message.image_data:
+        image_data_json = json.dumps(message.image_data.model_dump())
+
     db_message = models.Message(
         room_id=room_id,
         agent_id=message.agent_id,
@@ -38,6 +44,7 @@ async def create_message(
         participant_type=message.participant_type,
         participant_name=message.participant_name,
         thinking=message.thinking,
+        image_data=image_data_json,
     )
     db.add(db_message)
 

--- a/backend/domain/contexts.py
+++ b/backend/domain/contexts.py
@@ -4,8 +4,8 @@ Consolidated context data structures.
 Contains all context dataclasses for operations throughout the application.
 """
 
-from dataclasses import dataclass
-from typing import TYPE_CHECKING, Optional
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any, Optional
 
 from .agent_config import AgentConfigData
 from .task_identifier import TaskIdentifier
@@ -69,6 +69,20 @@ class OrchestrationContext:
 
 
 @dataclass
+class ImageData:
+    """
+    Image attachment data for sending to Claude SDK.
+
+    Attributes:
+        data: Base64-encoded image data
+        media_type: MIME type (e.g., 'image/png', 'image/jpeg')
+    """
+
+    data: str
+    media_type: str
+
+
+@dataclass
 class AgentResponseContext:
     """
     Context required for generating agent responses.
@@ -88,6 +102,7 @@ class AgentResponseContext:
         task_id: Optional unique identifier for tracking this task (for interruption)
         conversation_started: Optional timestamp when the conversation started
         has_situation_builder: Whether the room has a situation builder participant
+        image_data: Optional image attachment to include with the message
     """
 
     system_prompt: str
@@ -101,3 +116,4 @@ class AgentResponseContext:
     task_id: Optional[TaskIdentifier] = None
     conversation_started: Optional[str] = None
     has_situation_builder: bool = False
+    image_data: Optional[ImageData] = None

--- a/backend/models.py
+++ b/backend/models.py
@@ -125,6 +125,7 @@ class Message(Base):
     )  # For user messages: 'user', 'situation_builder', 'character'; NULL for agents
     participant_name = Column(String, nullable=True)  # Custom name for 'character' mode
     thinking = Column(Text, nullable=True)  # Agent's thinking process (for assistant messages)
+    image_data = Column(Text, nullable=True)  # JSON string of ImageAttachment (base64 image + media_type)
     timestamp = Column(DateTime, default=datetime.utcnow)
 
     # Indexes for frequently queried foreign keys

--- a/backend/utils/migrations.py
+++ b/backend/utils/migrations.py
@@ -71,6 +71,9 @@ async def run_migrations(engine: AsyncEngine):
         # Migration 15: Add joined_at to room_agents for invitation tracking
         await _add_joined_at_to_room_agents(conn)
 
+        # Migration 16: Add image_data column to messages for image attachments
+        await _add_image_data_to_messages(conn)
+
     logger.info("✅ Database migrations completed")
 
 
@@ -518,3 +521,17 @@ async def _add_joined_at_to_room_agents(conn):
         logger.info("  Adding joined_at column to room_agents table...")
         await conn.execute(text("ALTER TABLE room_agents ADD COLUMN joined_at DATETIME"))
         logger.info("  ✓ Added joined_at column")
+
+
+async def _add_image_data_to_messages(conn):
+    """Add image_data column to messages table for image attachments."""
+    # Check if image_data column exists
+    result = await conn.execute(
+        text("SELECT COUNT(*) as count FROM pragma_table_info('messages') WHERE name='image_data'")
+    )
+    row = result.first()
+
+    if row and row.count == 0:
+        logger.info("  Adding image_data column to messages table...")
+        await conn.execute(text("ALTER TABLE messages ADD COLUMN image_data TEXT"))
+        logger.info("  ✓ Added image_data column for image attachments")

--- a/frontend/src/components/ChatRoom.tsx
+++ b/frontend/src/components/ChatRoom.tsx
@@ -6,7 +6,7 @@ import { AgentManager } from './AgentManager';
 import { ChatHeader } from './chat-room/ChatHeader';
 import { MessageInput } from './chat-room/MessageInput';
 import { api } from '../utils/api';
-import type { Room, ParticipantType } from '../types';
+import type { Room, ParticipantType, ImageAttachment } from '../types';
 import { useToast } from '../contexts/ToastContext';
 
 interface ChatRoomProps {
@@ -164,8 +164,8 @@ export const ChatRoom = ({ roomId, onRoomRead, onMarkRoomAsRead, onRenameRoom }:
     }
   };
 
-  const handleSendMessage = (message: string, participantType: ParticipantType, characterName?: string) => {
-    sendMessage(message, participantType, characterName);
+  const handleSendMessage = (message: string, participantType: ParticipantType, characterName?: string, imageData?: ImageAttachment) => {
+    sendMessage(message, participantType, characterName, imageData);
   };
 
   if (!roomId) {

--- a/frontend/src/components/MessageList.tsx
+++ b/frontend/src/components/MessageList.tsx
@@ -192,6 +192,24 @@ export const MessageList = ({ messages }: MessageListProps) => {
                     </div>
                   )}
 
+                  {/* Image attachment */}
+                  {message.image_data && (
+                    <div className="mb-2">
+                      <img
+                        src={`data:${message.image_data.media_type};base64,${message.image_data.data}`}
+                        alt="Attached image"
+                        className="max-w-full max-h-80 rounded-xl shadow-sm cursor-pointer hover:opacity-95 transition-opacity"
+                        onClick={() => {
+                          // Open image in new tab for full view
+                          const win = window.open();
+                          if (win) {
+                            win.document.write(`<img src="data:${message.image_data!.media_type};base64,${message.image_data!.data}" />`);
+                          }
+                        }}
+                      />
+                    </div>
+                  )}
+
                   {/* Message content */}
                   <div
                     className={`relative group px-4 py-3 rounded-2xl shadow-sm ${

--- a/frontend/src/components/chat-room/MessageInput.tsx
+++ b/frontend/src/components/chat-room/MessageInput.tsx
@@ -1,26 +1,129 @@
-import { useState, FormEvent, KeyboardEvent } from 'react';
-import type { ParticipantType } from '../../types';
+import { useState, FormEvent, KeyboardEvent, DragEvent, useRef } from 'react';
+import type { ParticipantType, ImageAttachment } from '../../types';
 
 interface MessageInputProps {
   isConnected: boolean;
-  onSendMessage: (message: string, participantType: ParticipantType, characterName?: string) => void;
+  onSendMessage: (message: string, participantType: ParticipantType, characterName?: string, imageData?: ImageAttachment) => void;
 }
 
 export const MessageInput = ({ isConnected, onSendMessage }: MessageInputProps) => {
   const [inputMessage, setInputMessage] = useState('');
   const [participantType, setParticipantType] = useState<ParticipantType>('user');
   const [characterName, setCharacterName] = useState('');
+  const [imageAttachment, setImageAttachment] = useState<ImageAttachment | null>(null);
+  const [imagePreview, setImagePreview] = useState<string | null>(null);
+  const [isDragging, setIsDragging] = useState(false);
+  const fileInputRef = useRef<HTMLInputElement>(null);
 
   // State to toggle the persona menu
   const [showPersonaMenu, setShowPersonaMenu] = useState(false);
 
+  // Supported image types
+  const SUPPORTED_IMAGE_TYPES = ['image/png', 'image/jpeg', 'image/gif', 'image/webp'];
+  const MAX_IMAGE_SIZE = 10 * 1024 * 1024; // 10MB
+
+  // Process a file into base64
+  const processImageFile = async (file: File): Promise<void> => {
+    if (!SUPPORTED_IMAGE_TYPES.includes(file.type)) {
+      alert('Please upload a PNG, JPEG, GIF, or WebP image.');
+      return;
+    }
+
+    if (file.size > MAX_IMAGE_SIZE) {
+      alert('Image size must be less than 10MB.');
+      return;
+    }
+
+    try {
+      const base64 = await fileToBase64(file);
+      setImageAttachment({
+        data: base64,
+        media_type: file.type,
+      });
+      setImagePreview(URL.createObjectURL(file));
+    } catch (error) {
+      console.error('Error processing image:', error);
+      alert('Failed to process image. Please try again.');
+    }
+  };
+
+  // Convert file to base64
+  const fileToBase64 = (file: File): Promise<string> => {
+    return new Promise((resolve, reject) => {
+      const reader = new FileReader();
+      reader.onload = () => {
+        const result = reader.result as string;
+        // Remove the data URL prefix (e.g., "data:image/png;base64,")
+        const base64 = result.split(',')[1];
+        resolve(base64);
+      };
+      reader.onerror = reject;
+      reader.readAsDataURL(file);
+    });
+  };
+
+  // Handle drag events
+  const handleDragOver = (e: DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    e.stopPropagation();
+    setIsDragging(true);
+  };
+
+  const handleDragLeave = (e: DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    e.stopPropagation();
+    setIsDragging(false);
+  };
+
+  const handleDrop = async (e: DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    e.stopPropagation();
+    setIsDragging(false);
+
+    const files = e.dataTransfer.files;
+    if (files.length > 0) {
+      const file = files[0];
+      if (file.type.startsWith('image/')) {
+        await processImageFile(file);
+      }
+    }
+  };
+
+  // Handle file input change
+  const handleFileChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const files = e.target.files;
+    if (files && files.length > 0) {
+      await processImageFile(files[0]);
+    }
+    // Reset input so same file can be selected again
+    if (fileInputRef.current) {
+      fileInputRef.current.value = '';
+    }
+  };
+
+  // Remove attached image
+  const removeImage = () => {
+    setImageAttachment(null);
+    if (imagePreview) {
+      URL.revokeObjectURL(imagePreview);
+    }
+    setImagePreview(null);
+  };
+
   const handleSubmit = (e: FormEvent) => {
     e.preventDefault();
     console.log('[MessageInput] handleSubmit called');
-    if (inputMessage.trim() && isConnected) {
+    // Allow sending if there's text OR an image
+    if ((inputMessage.trim() || imageAttachment) && isConnected) {
       console.log('[MessageInput] Calling onSendMessage from handleSubmit');
-      onSendMessage(inputMessage, participantType, participantType === 'character' ? characterName : undefined);
+      onSendMessage(
+        inputMessage || '[Image]',
+        participantType,
+        participantType === 'character' ? characterName : undefined,
+        imageAttachment || undefined
+      );
       setInputMessage('');
+      removeImage();
     }
   };
 
@@ -29,10 +132,17 @@ export const MessageInput = ({ isConnected, onSendMessage }: MessageInputProps) 
     if (e.key === 'Enter' && (e.ctrlKey || e.metaKey)) {
       e.preventDefault();
       console.log('[MessageInput] handleKeyDown - Ctrl+Enter pressed');
-      if (inputMessage.trim() && isConnected) {
+      // Allow sending if there's text OR an image
+      if ((inputMessage.trim() || imageAttachment) && isConnected) {
         console.log('[MessageInput] Calling onSendMessage from handleKeyDown');
-        onSendMessage(inputMessage, participantType, participantType === 'character' ? characterName : undefined);
+        onSendMessage(
+          inputMessage || '[Image]',
+          participantType,
+          participantType === 'character' ? characterName : undefined,
+          imageAttachment || undefined
+        );
         setInputMessage('');
+        removeImage();
       }
     }
     // Allow Enter to create line breaks (default behavior)
@@ -53,7 +163,59 @@ export const MessageInput = ({ isConnected, onSendMessage }: MessageInputProps) 
   };
 
   return (
-    <div className="bg-white/90 backdrop-blur border-t border-slate-100 p-2 sm:p-4 shadow-[0_-4px_6px_-1px_rgba(0,0,0,0.02)] z-20">
+    <div
+      className={`bg-white/90 backdrop-blur border-t border-slate-100 p-2 sm:p-4 shadow-[0_-4px_6px_-1px_rgba(0,0,0,0.02)] z-20 transition-colors ${
+        isDragging ? 'bg-indigo-50 border-indigo-300' : ''
+      }`}
+      onDragOver={handleDragOver}
+      onDragLeave={handleDragLeave}
+      onDrop={handleDrop}
+    >
+      {/* Drag overlay indicator */}
+      {isDragging && (
+        <div className="absolute inset-0 bg-indigo-100/80 border-2 border-dashed border-indigo-400 rounded-lg flex items-center justify-center z-30 pointer-events-none">
+          <div className="text-center">
+            <svg className="w-12 h-12 mx-auto text-indigo-500 mb-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z" />
+            </svg>
+            <p className="text-indigo-600 font-medium">Drop image here</p>
+          </div>
+        </div>
+      )}
+
+      {/* Image Preview */}
+      {imagePreview && (
+        <div className="mb-3 flex items-start gap-2">
+          <div className="relative group">
+            <img
+              src={imagePreview}
+              alt="Attachment preview"
+              className="max-h-32 max-w-48 rounded-lg border border-slate-200 shadow-sm object-contain"
+            />
+            <button
+              type="button"
+              onClick={removeImage}
+              className="absolute -top-2 -right-2 w-6 h-6 bg-red-500 text-white rounded-full flex items-center justify-center shadow-md hover:bg-red-600 transition-colors"
+              title="Remove image"
+            >
+              <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+              </svg>
+            </button>
+          </div>
+          <span className="text-xs text-slate-500 mt-1">Image attached</span>
+        </div>
+      )}
+
+      {/* Hidden file input */}
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept="image/png,image/jpeg,image/gif,image/webp"
+        onChange={handleFileChange}
+        className="hidden"
+      />
+
       {/* Persona Selection Popup (Only visible when toggled) */}
       {showPersonaMenu && (
         <div className="mb-3 p-3 bg-slate-50 rounded-xl border border-slate-200 animate-fadeIn">
@@ -106,6 +268,23 @@ export const MessageInput = ({ isConnected, onSendMessage }: MessageInputProps) 
           {getPersonaIcon()}
         </button>
 
+        {/* Image Attach Button */}
+        <button
+          type="button"
+          onClick={() => fileInputRef.current?.click()}
+          className={`flex-shrink-0 w-10 h-10 sm:w-12 sm:h-12 rounded-full flex items-center justify-center transition-all ${
+            imageAttachment
+              ? 'bg-indigo-100 text-indigo-600 hover:bg-indigo-200'
+              : 'bg-slate-100 text-slate-600 hover:bg-slate-200'
+          }`}
+          title="Attach image (or drag & drop)"
+          disabled={!isConnected}
+        >
+          <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z" />
+          </svg>
+        </button>
+
         {/* Streamlined Input Field */}
         <textarea
           value={inputMessage}
@@ -125,7 +304,7 @@ export const MessageInput = ({ isConnected, onSendMessage }: MessageInputProps) 
         {/* Icon-Only Send Button (Saves width) */}
         <button
           type="submit"
-          disabled={!isConnected || !inputMessage.trim()}
+          disabled={!isConnected || (!inputMessage.trim() && !imageAttachment)}
           className="flex-shrink-0 w-10 h-10 sm:w-12 sm:h-12 bg-indigo-600 text-white rounded-full flex items-center justify-center hover:bg-indigo-700 active:scale-95 transition-all shadow-md disabled:bg-slate-300 disabled:shadow-none"
         >
           <svg className="w-5 h-5 translate-x-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">

--- a/frontend/src/hooks/usePolling.ts
+++ b/frontend/src/hooks/usePolling.ts
@@ -1,10 +1,10 @@
 import { useEffect, useRef, useState, useCallback } from 'react';
-import type { Message } from '../types';
+import type { Message, ImageAttachment } from '../types';
 import { getApiKey } from '../utils/api';
 
 interface UsePollingReturn {
   messages: Message[];
-  sendMessage: (content: string, participant_type?: string, participant_name?: string) => void;
+  sendMessage: (content: string, participant_type?: string, participant_name?: string, image_data?: ImageAttachment) => void;
   isConnected: boolean;
   setMessages: React.Dispatch<React.SetStateAction<Message[]>>;
   resetMessages: () => Promise<void>;
@@ -232,7 +232,7 @@ export const usePolling = (roomId: number | null): UsePollingReturn => {
     };
   }, [roomId, fetchAllMessages, pollNewMessages, pollChattingAgents]);
 
-  const sendMessage = async (content: string, participant_type?: string, participant_name?: string) => {
+  const sendMessage = async (content: string, participant_type?: string, participant_name?: string, image_data?: ImageAttachment) => {
     if (!roomId) return;
 
     try {
@@ -255,6 +255,9 @@ export const usePolling = (roomId: number | null): UsePollingReturn => {
       }
       if (participant_name) {
         messageData.participant_name = participant_name;
+      }
+      if (image_data) {
+        messageData.image_data = image_data;
       }
 
       const response = await fetch(`${API_BASE_URL}/rooms/${roomId}/messages/send`, {

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -40,6 +40,11 @@ export interface AgentConfig {
   [key: string]: string;
 }
 
+export interface ImageAttachment {
+  data: string;  // Base64-encoded image data
+  media_type: string;  // MIME type (e.g., 'image/png', 'image/jpeg')
+}
+
 export interface Message {
   id: number | string;  // Can be temp_id (string) during streaming or real DB id (number) after
   room_id?: number;
@@ -57,12 +62,14 @@ export interface Message {
   is_streaming?: boolean;  // True while message is being streamed
   temp_id?: string;  // Temporary ID for streaming messages
   is_skipped?: boolean;  // True when agent chose to skip/ignore the message
+  image_data?: ImageAttachment | null;  // Optional attached image
 }
 
 export interface MessageCreate {
   content: string;
   role: string;
   agent_id?: number | null;
+  image_data?: ImageAttachment | null;  // Optional attached image
 }
 
 export interface Room {


### PR DESCRIPTION
Frontend changes:
- Add ImageAttachment type for base64 image data
- Update MessageInput with drag-and-drop zone and image preview
- Add image attachment button for manual file selection
- Update MessageList to display attached images
- Update usePolling to send image_data with messages
- Update ChatRoom to pass image data through handlers

Backend changes:
- Add ImageAttachment schema in schemas.py
- Add image_data column to Message model
- Add migration for image_data column
- Update CRUD to serialize/deserialize image_data as JSON
- Update AgentResponseContext with image_data field
- Update SDK manager to send images using content blocks
- Update response generator to extract images from messages

Images are stored as base64-encoded JSON in the database and passed to Claude SDK using the Messages API content block format.