### PR TITLE
Harden access control and fix MCP room handling

### DIFF
--- a/backend/auth.py
+++ b/backend/auth.py
@@ -367,5 +367,5 @@ def require_admin(request: Request):
     if user_role != "admin":
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
-            detail="This action requires admin privileges. Guests can chat but cannot modify rooms, agents, or messages.",
+            detail="This action requires admin privileges.",
         )

--- a/backend/routers/agents.py
+++ b/backend/routers/agents.py
@@ -15,9 +15,9 @@ from sqlalchemy.ext.asyncio import AsyncSession
 router = APIRouter()
 
 
-@router.post("", response_model=schemas.Agent)
+@router.post("", response_model=schemas.Agent, dependencies=[Depends(require_admin)])
 async def create_agent(agent: schemas.AgentCreate, db: AsyncSession = Depends(get_db)):
-    """Create a new agent as an independent entity."""
+    """Create a new agent as an independent entity. (Admin only)"""
     return await crud.create_agent(db, agent)
 
 

--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -23,7 +23,7 @@ async def login(request: Request):
 
     Supports both admin and guest passwords:
     - Admin password: Full access to all features
-    - Guest password: Read-only access, can chat but cannot modify rooms/agents/messages
+    - Guest password: Limited access to their own rooms and chat; admin-only operations remain restricted
 
     Security features:
     - Rate limited to 20 attempts per minute per IP address (via slowapi)

--- a/backend/routers/debug.py
+++ b/backend/routers/debug.py
@@ -6,13 +6,14 @@ These endpoints provide access to cache statistics and other debugging informati
 
 from typing import Dict
 
-from fastapi import APIRouter
+from auth import require_admin
+from fastapi import APIRouter, Depends
 from services.cache_service import get_cache_service
 
 router = APIRouter()
 
 
-@router.get("/cache/stats")
+@router.get("/cache/stats", dependencies=[Depends(require_admin)])
 async def get_cache_stats() -> Dict[str, int]:
     """
     Get current cache statistics.
@@ -30,7 +31,7 @@ async def get_cache_stats() -> Dict[str, int]:
     return cache_service.get_stats()
 
 
-@router.post("/cache/cleanup")
+@router.post("/cache/cleanup", dependencies=[Depends(require_admin)])
 async def cleanup_cache() -> Dict[str, str]:
     """
     Manually trigger cache cleanup to remove expired entries.
@@ -43,7 +44,7 @@ async def cleanup_cache() -> Dict[str, str]:
     return {"status": "success", "message": "Cache cleanup completed"}
 
 
-@router.post("/cache/clear")
+@router.post("/cache/clear", dependencies=[Depends(require_admin)])
 async def clear_cache() -> Dict[str, str]:
     """
     Clear all cache entries.


### PR DESCRIPTION
### Motivation
- Close authorization gaps where guest users could perform admin-level operations (agents, cache control) contrary to the intended access model.  
- Prevent arbitrary room access and message posting via the MCP tools which could allow guests to interact with rooms they don't own.  
- Fix an API mismatch in MCP room creation that passed the wrong parameters to the CRUD layer and would raise runtime errors.  

### Description
- Restrict `POST /agents` by adding `dependencies=[Depends(require_admin)]` so only admins can create agents and update the route docstring to note admin-only behavior.  
- Protect debug cache endpoints in `backend/routers/debug.py` by adding `Depends(require_admin)` to `get_cache_stats`, `cleanup_cache`, and `clear_cache`.  
- Simplify the `require_admin` error message in `backend/auth.py` to avoid misleading text about guest capabilities, and update the auth route docstring to reflect guests have limited access to their own rooms.  
- Harden MCP endpoints (`backend/routers/mcp_tools.py`) by injecting `RequestIdentity` from `get_request_identity`, scoping direct rooms and room creation to `owner_id = 'admin' if identity.role == 'admin' else identity.user_id`, fixing the `create_room` call to pass a `schemas.RoomCreate` and an `owner_id`, and enforcing `ensure_room_access` in `send_to_room`.  

### Testing
- No automated tests were executed as part of this PR.  
- Recommended follow-ups: run the test suite with `uv run pytest --cov=backend --cov-report=term-missing` and specifically run `pytest -m auth` and integration message/room tests to validate access control behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69490d5589dc8328819e8a9deda797b6)